### PR TITLE
fixes #6 : graphql autoloading using similar strategy as django model…

### DIFF
--- a/src/backend/schema.py
+++ b/src/backend/schema.py
@@ -1,19 +1,20 @@
+
 import graphene
 
-import backend.core.query
-import backend.blog.query
+from .utils import get_queries_from_apps, get_mutations_from_apps
 
-import backend.core.mutation
-import backend.blog.mutation
+name = 'Query'
+Query = type(
+    name,
+    get_queries_from_apps() + (graphene.ObjectType,),
+    dict()
+)
 
-class Query(backend.core.query.Query, backend.blog.query.Query, graphene.ObjectType):
-    # This class will inherit from multiple Queries
-    # as we begin to add more apps to our project
-    pass
-
-class Mutation(backend.core.mutation.Mutation, backend.blog.mutation.Mutation, graphene.ObjectType):
-    # This class will inherit from multiple Mutations
-    # as we begin to add more apps to our project
-    pass
+name = 'Mutation'
+Mutation = type(
+    name,
+    get_mutations_from_apps() + (graphene.ObjectType,),
+    dict()
+)
 
 schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/src/backend/utils.py
+++ b/src/backend/utils.py
@@ -1,0 +1,42 @@
+from importlib import import_module
+import inspect
+
+import graphene
+from django.apps import apps
+
+def get_queries_from_apps(module_name='query'):
+    queries = []
+    for app in apps.get_app_configs():
+        try:
+            modentry = "%s.%s" % (app.name, module_name)
+            mod = import_module(modentry)
+            clsmembers = inspect.getmembers(mod, inspect.isclass)
+            clsmembers = [i for i, k in inspect.getmembers(mod, inspect.isclass) if k.__module__ == modentry]
+            for i in clsmembers:
+                try:
+                    cls = getattr(mod, i)
+                    queries.append(cls)
+                except AttributeError:
+                    pass
+        except ModuleNotFoundError:
+            pass
+    return tuple(queries)
+
+def get_mutations_from_apps(module_name='mutation'):
+    mutations = []
+    for app in apps.get_app_configs():
+        try:
+            modentry = "%s.%s" % (app.name, module_name)
+            mod = import_module(modentry)
+            clsmembers = inspect.getmembers(mod, inspect.isclass)
+            clsmembers = [i for i, k in inspect.getmembers(mod, inspect.isclass) if k.__module__ == modentry]
+            for i in clsmembers:
+                try:
+                    cls = getattr(mod, i)
+                    if graphene.ObjectType in cls.__bases__:
+                        mutations.append(cls)
+                except AttributeError:
+                    pass
+        except ModuleNotFoundError:
+            pass
+    return tuple(mutations)


### PR DESCRIPTION

Implemented dynamic discovery of graphql queries and mutations using a similar technique to that used by django for models and configs.

1. Traverse all django apps and look for modules named 'query' or 'mutation'.
2. Any classes declared in 'query' are added to the list.
3. Classes declared in Mutations who derive from graphene.ObjectType are added to the list.

fixes #6 